### PR TITLE
Aquastation JSON & Ruin Traits

### DIFF
--- a/_maps/aquastation.json
+++ b/_maps/aquastation.json
@@ -1,0 +1,25 @@
+{
+	"version": 1,
+	"map_name": "Aquastation",
+	"map_path": "map_files/AquaStation",
+	"map_file": "AquaStation.dmm",
+	"space_ruin_levels": 0,
+	"space_empty_levels": 0,
+	"planetary": 1,
+	"shuttles": {
+		"cargo": "cargo_delta",
+		"ferry": "ferry_kilo",
+		"whiteship": "whiteship_birdshot",
+		"emergency": "emergency_delta"
+	},
+	"traits": [
+		{
+			"Mining": true,
+			"Baseturf": "/turf/open/misc/asteroid",
+			"Linkage": null,
+			"Gravity": true,
+			"Ocean Ruins": true,
+			"No Parallax": true
+		}
+	]
+}

--- a/code/__DEFINES/~nova_defines/mapping.dm
+++ b/code/__DEFINES/~nova_defines/mapping.dm
@@ -1,3 +1,6 @@
+#define ZTRAIT_OCEAN_RUINS "Ocean Ruins"
+#define ZTRAIT_TRENCH_RUINS "Trench Ruins"
+
 #define RADIO_CHANNEL_CYBERSUN "Cybersun"
 #define RADIO_KEY_CYBERSUN "q"
 #define RADIO_TOKEN_CYBERSUN ":q"

--- a/modular_nova/master_files/code/_globalvars/configuration.dm
+++ b/modular_nova/master_files/code/_globalvars/configuration.dm
@@ -72,3 +72,14 @@ GLOBAL_VAR_INIT(looc_allowed, TRUE)
 
 // Are borgs/silicons blacklisted from entering the gateway
 /datum/config_entry/flag/borg_gateway_blacklist
+
+/// OCEAN RUIN BUDGETS ///
+/datum/config_entry/number/ocean_budget
+	default = 6
+	integer = FALSE
+	min_val = 0
+
+/datum/config_entry/number/trench_budget
+	default = 6
+	integer = FALSE
+	min_val = 0

--- a/modular_nova/master_files/code/controllers/subsystem/mapping.dm
+++ b/modular_nova/master_files/code/controllers/subsystem/mapping.dm
@@ -2,6 +2,19 @@
 /datum/controller/subsystem/mapping/proc/is_planetary_with_space()
 	return is_planetary() && current_map.allow_space_when_planetary
 
+/// Sets up modular ruin archetypes
+/datum/controller/subsystem/mapping/setup_ruins()
+	// Ocean Ruins, Aquastation
+	var/list/ocean_ruins = levels_by_trait(ZTRAIT_OCEAN_RUINS)
+	if(ocean_ruins.len)
+		seedRuins(ocean_ruins, CONFIG_GET(number/ocean_budget), list(/area/ocean/generated), themed_ruins[ZTRAIT_OCEAN_RUINS], clear_below = TRUE)
+
+	// Trench Ruins, Aquastation
+	var/list/trench_ruins = levels_by_trait(ZTRAIT_TRENCH_RUINS)
+	if(trench_ruins.len)
+		seedRuins(trench_ruins, CONFIG_GET(number/trench_budget), list(/area/ocean/trench/generated), themed_ruins[ZTRAIT_TRENCH_RUINS], clear_below = TRUE)
+	return ..()
+
 
 /datum/map_config
 	/// Are we allowing space even if we're planetary?

--- a/modular_nova/modules/liquids/code/ocean_ruins.dm
+++ b/modular_nova/modules/liquids/code/ocean_ruins.dm
@@ -1,4 +1,7 @@
 /datum/map_template/ruin/ocean
+	ruin_type = ZTRAIT_OCEAN_RUINS
+	cost = 1
+	allow_duplicates =  FALSE
 	prefix = "_maps/RandomRuins/OceanRuins/"
 
 /datum/map_template/ruin/ocean/fissure


### PR DESCRIPTION
Creates & formats a basic JSON to load the map. This can be tweaked further depending on your needs - see the other json files in _maps to see what to do and how.

This ALSO includes the code changes for ocean ruins to hypothetically spawn. I say hypothetically because while their datums still exist in ocean_ruins.dm; they were COMPLETELY removed here. ough,.,

To convert this map to a two-z multi-z map - trench turfs & etc on the bottom, ocean proper on the top, replace the traits block with the following:

	"traits": [
		{
			"Up": true,
			"Mining": true,
			"Linkage": null,
			"Gravity": true,
			"Baseturf": "/turf/open/misc/asteroid",
			"Trench Ruins": true,
			"No Parallax": true
		},
		{
			"Down": true,
			"Baseturf": "/turf/open/openspace",
			"Linkage": null,
			"Gravity": true,
			"Ocean Ruins": true,
			"No Parallax": true
		}
	]
